### PR TITLE
rewrite example

### DIFF
--- a/examples/sycl/pvc/pvc_gemm.cpp
+++ b/examples/sycl/pvc/pvc_gemm.cpp
@@ -63,7 +63,7 @@ struct Options {
   Options():
     help(false),
     error(false),
-    m(5120), n(4096), k(4096), l(1), iterations(20),
+    m(512), n(512), k(16), l(1), iterations(1),
     alpha(1.f), beta(0.f)
   { }
 
@@ -76,7 +76,7 @@ struct Options {
       return;
     }
 
-    cmd.get_cmd_line_argument("m", m, 5120);
+    cmd.get_cmd_line_argument("m", m, 4096);
     cmd.get_cmd_line_argument("n", n, 4096);
     cmd.get_cmd_line_argument("k", k, 4096);
     cmd.get_cmd_line_argument("l", l, 1);
@@ -156,37 +156,84 @@ struct ExampleRunner {
   bool verify(const ProblemShapeType& problem_size, ElementCompute alpha, ElementCompute beta) {
     auto [M, N, K, L] = problem_size;
 
-    cutlass::TensorRef ref_A(block_A.get(), LayoutA::packed({M, K}));
-    cutlass::TensorRef ref_B(block_B.get(), LayoutB::packed({K, N}));
-    cutlass::TensorRef ref_C(block_C.get(), LayoutC::packed({M, N}));
-    cutlass::TensorRef ref_D(block_ref_D.get(), LayoutD::packed({M, N}));
+    // cutlass::TensorRef ref_A(block_A.get(), LayoutA::packed({M, K}));
+    // cutlass::TensorRef ref_B(block_B.get(), LayoutB::packed({K, N}));
+    // cutlass::TensorRef ref_C(block_C.get(), LayoutC::packed({M, N}));
+    // cutlass::TensorRef ref_D(block_ref_D.get(), LayoutD::packed({M, N}));
 
-    cutlass::reference::device::GemmComplex(
-          {M, N, K},
-          alpha,
-          ref_A,
-          cutlass::ComplexTransform::kNone,
-          ref_B,
-          cutlass::ComplexTransform::kNone,
-          beta,
-          ref_C,
-          ref_D,
-          ElementAccumulator(0),
-          L,     // batch_count
-          M * K, // batch_stride_A
-          K * N, // batch_stride_B
-          M * N, // batch_stride_C
-          M * N  // batch_stride_D
-        );
+    // cutlass::reference::device::GemmComplex(
+    //       {M, N, K},
+    //       alpha,
+    //       ref_A,
+    //       cutlass::ComplexTransform::kNone,
+    //       ref_B,
+    //       cutlass::ComplexTransform::kNone,
+    //       beta,
+    //       ref_C,
+    //       ref_D,
+    //       ElementAccumulator(0),
+    //       L,     // batch_count
+    //       M * K, // batch_stride_A
+    //       K * N, // batch_stride_B
+    //       M * N, // batch_stride_C
+    //       M * N  // batch_stride_D
+    //     );
 
-    syclcompat::wait();
+    // syclcompat::wait();
 
-    // Check if output from CUTLASS kernel and reference kernel are equal or not
-    bool passed = cutlass::reference::device::BlockCompareEqual(
-      block_ref_D.get(), block_D.get(), block_D.size());
+    // // Check if output from CUTLASS kernel and reference kernel are equal or not
+    // bool passed = cutlass::reference::device::BlockCompareEqual(
+    //   block_ref_D.get(), block_D.get(), block_D.size());
+    #if 1
+    std::vector<float> h_D(M * N);
+    std::vector<bfloat16_t> h_A(M * K);
+    std::vector<bfloat16_t> h_B(K * N);
+    
+    syclcompat::memcpy<bfloat16_t>(h_A.data(), block_A.get(), M * K);
+    syclcompat::memcpy<bfloat16_t>(h_B.data(), block_B.get(), N * K);
+    syclcompat::memcpy<float>(h_D.data(), block_D.get(), M * N);
+  syclcompat::wait();
 
-    return passed;
+  std::cout << "M : " << M << " N : " << N << " K : " <<K << std::endl;
+
+  int cnt = 0;
+  bool is_normal = true;
+    for(int i = 0; i < M; i++) {
+      for(int j = 0; j < N; j++) {
+        float sum = 0;
+        for(int z = 0; z < K; z++) {
+            sum += h_A.data()[i * K + z] *  h_B.data()[z * N + j];
+        }
+      float val = h_D.data()[i * N + j];
+      float expect = sum;
+      if(i ==0 &&j == 0) {
+        std::cout << "sum: " << sum << std::endl;
+      }
+
+      if (isnormal(val) && isnormal(expect)) {
+        auto error = std::abs((expect - val) / val);
+        if (error > 0.005f) {
+          return false;
+          cnt++;
+        }
+      } else {
+        is_normal = false;
+      }
+      }
+    }
+    std::cout << "ref : "<< h_D.data()[0] << " cnt : " << cnt << std::endl;
+    return cnt == 0;
+    #endif
+    // return passed;
   }
+
+template <typename T> static void fill_matrix(std::vector<T> &M) {
+  std::random_device dev;
+  std::mt19937 rng(dev());
+  std::uniform_real_distribution<float> dist((T)0.0, (T)1.0);
+  std::generate(std::begin(M), std::end(M),
+                [&] { return static_cast<T>(dist(rng)); });
+}
 
   /// Initialize operands to be used in the GEMM and reference GEMM
   void initialize(const ProblemShapeType& problem_size) {
@@ -204,9 +251,19 @@ struct ExampleRunner {
     block_D.reset(M * N * L);
     block_ref_D.reset(M * N * L);
 
-    initialize_block(block_A, seed + 2023);
-    initialize_block(block_B, seed + 2022);
-    initialize_block(block_C, seed + 2021);
+    std::vector<bfloat16_t> h_A(M * K);
+    std::vector<bfloat16_t> h_B(K * N);
+
+    fill_matrix(h_A);
+    fill_matrix(h_B);
+    syclcompat::memcpy<bfloat16_t>(block_A.get(), h_A.data(), M * K);
+    syclcompat::memcpy<bfloat16_t>(block_B.get(), h_B.data(), N * K);
+    
+    
+
+    // initialize_block(block_A, seed + 2023);
+    // initialize_block(block_B, seed + 2022);
+    // initialize_block(block_C, seed + 2021);
   }
 
   void run(const Options& options, const cutlass::KernelHardwareInfo& hw_info) {
@@ -237,6 +294,7 @@ struct ExampleRunner {
     syclcompat::wait();
 
     // Verify that the result is correct
+    // bool passed = true;
     bool passed = verify(problem_size, options.alpha, options.beta);
     std::cout << "Disposition: " << (passed ? "Passed" : "Failed") << std::endl;
 
@@ -306,15 +364,15 @@ int main(int argc, const char** argv)
   using LayoutC = cutlass::layout::RowMajor;
   using LayoutD = cutlass::layout::RowMajor;
 
-  using GmemTiledCopyA = XE_2D_U16x8x16x4x2_LD_N;
-  using GmemTiledCopyB = XE_2D_U16x16x16x2x2_V;
+  using GmemTiledCopyA = XE_2D_U16x8x16_LD_N;
+  using GmemTiledCopyB = XE_2D_U16x16x16_LD_V;
 
   // Workgroup-level tile
-  using TileShape = Shape<_256, _256, _32>;
+  using TileShape = Shape<_256, _128, _32>;
 
   using TiledMma = TiledMMA<MMA_Atom<XE_8x16x16_F32BF16BF16F32_TT>,
-          Layout<Shape<_1,_1,_1>>,
-          Tile<_32,_64,_32>>; // Subgroup level-tile
+          Layout<Shape<_8,_2,_1>>,
+          Tile<Underscore,Underscore,Underscore>>; // Subgroup level-tile
 
   constexpr int PipelineStages = 3;
   using GEMMDispatchPolicy = cutlass::gemm::MainloopIntelPVC<PipelineStages>;
@@ -333,9 +391,9 @@ int main(int argc, const char** argv)
           ElementOutput,
           cutlass::gemm::TagToStrideC_t<LayoutD>,
           FusionCallBacks,
-          XE_2D_U32x8x16x1x1_LD_N,
+          XE_2D_U32x8x16_LD_N,
           void, void,
-          XE_2D_U32x8x16x1x1_ST_N,
+          XE_2D_U32x8x16_ST_N,
           void, void>;
 
 // Mainloop

--- a/include/cutlass/epilogue/collective/intel_pvc_epilogue.hpp
+++ b/include/cutlass/epilogue/collective/intel_pvc_epilogue.hpp
@@ -118,6 +118,18 @@ public:
   static_assert(std::is_same_v<SmemLayoutAtomC, void>, "Copy operation to shared memory is not supported");
   static_assert(std::is_same_v<SmemLayoutAtomD, void>, "Copy operation to shared memory is not supported");
 
+  using Trait_C = Copy_Traits<GmemTiledCopyC>;
+  using XE_Copy_C = decltype(make_tiled_copy(Copy_Atom<Trait_C, ElementC>{}
+                                             .with(static_cast<ElementC const*>(nullptr), int32_t(0), int32_t(0), int32_t(0)),
+                                             Layout<Shape<_1, Int<SubgroupSize>>>{},
+                                             make_layout(make_shape(get<0>(typename Trait_C::Shape_MN{}),
+                                                                    get<1>(typename Trait_C::Shape_MN{}) / Int<SubgroupSize>{}))));
+  using Trait_D = Copy_Traits<GmemTiledCopyD>;
+  using XE_Copy_D = decltype(make_tiled_copy(Copy_Atom<Trait_D, ElementD>{}
+                                             .with(static_cast<ElementD const*>(nullptr),int32_t(0), int32_t(0), int32_t(0)),
+                                             Layout<Shape<_1, Int<SubgroupSize>>>{},
+                                             make_layout(make_shape(get<0>(typename Trait_D::Shape_MN{}),
+                                                                    get<1>(typename Trait_D::Shape_MN{}) / Int<SubgroupSize>{}))));
 private:
   constexpr static bool is_source_supported = not cute::is_void_v<ElementC>;
   constexpr static bool is_destination_supported = not cute::is_void_v<ElementD>;
@@ -154,13 +166,7 @@ public:
 
   // Device side epilogue params
   struct Params {
-    using XE_Copy_C = decltype(make_xe_2d_copy<CopyOpG2R>(
-        make_tensor(static_cast<ElementC const*>(nullptr),
-            repeat_like(StrideC{}, int32_t(0)), StrideC{})));
-    using XE_Copy_D = decltype(make_xe_2d_copy<CopyOpR2G>(
-        make_tensor(static_cast<ElementD const*>(nullptr),
-            repeat_like(StrideD{}, int32_t(0)), StrideD{})));
-
+    Arguments args;
     typename FusionCallbacks::Params thread{};
     XE_Copy_C xe_load_c;
     XE_Copy_D xe_store_d;
@@ -180,19 +186,26 @@ public:
     auto problem_shape_MNKL = append<4>(problem_shape, 1);
     auto [M, N, K, L] = problem_shape_MNKL;
 
-    typename Params::XE_Copy_C xe_load_c = {};
+    XE_Copy_C xe_load_c = {};
     if constexpr (is_source_supported) {
-      Tensor tensor_c = make_tensor(args.ptr_C, make_layout(make_shape(M,N,L), args.dC));
-      xe_load_c = make_xe_2d_copy<CopyOpG2R>(tensor_c);
+      xe_load_c = make_tiled_copy(Copy_Atom<Copy_Traits<CopyOpG2R>, ElementC>{}.with(
+                                  args.ptr_C, N, M, N),
+                                  Layout<Shape<_1, Int<SubgroupSize>>>{},
+                                  make_layout(make_shape(get<0>(typename Trait_C::Shape_MN{}),
+                                                         get<1>(typename Trait_C::Shape_MN{}) / Int<SubgroupSize>{})));
     }
 
-    typename Params::XE_Copy_D xe_store_d = {};
+    XE_Copy_D xe_store_d = {};
     if constexpr (is_destination_supported) {
-      Tensor tensor_d = make_tensor(args.ptr_D, make_layout(make_shape(M,N,L), args.dD));
-      xe_store_d = make_xe_2d_copy<CopyOpR2G>(tensor_d);
+      xe_store_d = make_tiled_copy(Copy_Atom<Copy_Traits<CopyOpR2G>, ElementD>{}.with(
+                                   args.ptr_D, N, M, N),
+                                   Layout<Shape<_1, Int<SubgroupSize>>>{},
+                                   make_layout(make_shape(get<0>(typename Trait_D::Shape_MN{}),
+                                                          get<1>(typename Trait_D::Shape_MN{}) / Int<SubgroupSize>{})));
     }
 
     return {
+      args,
       FusionCallbacks::to_underlying_arguments(problem_shape, args.thread, workspace),
       xe_load_c,
       xe_store_d
@@ -255,7 +268,18 @@ public:
     using namespace cute;
 
     using MmaAtomShape = typename TiledMma::AtomShape_MNK;
-    using SubgroupTileShape = decltype(tile_shape(TiledMma()));
+    static constexpr auto BLK_M = get<0>(CtaTileMNK{});
+    static constexpr auto BLK_N = get<1>(CtaTileMNK{});
+    static constexpr auto BLK_K = get<2>(CtaTileMNK{});
+    // static_assert(is_same_v<typename TiledMma::ThrLayoutVMNK, int>, "assertation fail");
+    static constexpr auto ATOM_M = get<1>(typename TiledMma::ThrLayoutVMNK{}.shape());
+    static constexpr auto ATOM_N = get<2>(typename TiledMma::ThrLayoutVMNK{}.shape());
+    static constexpr auto ATOM_K = get<3>(typename TiledMma::ThrLayoutVMNK{}.shape());
+    
+    static constexpr auto SG_M = ceil_div(BLK_M, ATOM_M);
+    static constexpr auto SG_N = ceil_div(BLK_N, ATOM_N);
+    static constexpr auto SG_K = ceil_div(BLK_K, ATOM_K);
+    using SubgroupTileShape = Shape<decltype(SG_M), decltype(SG_N), decltype(SG_K)>;
 
     static constexpr int FragsM = get<0>(SubgroupTileShape{}) / get<0>(MmaAtomShape()); // A frags per sub_group
     static constexpr int FragsN = get<1>(SubgroupTileShape{}) / get<1>(MmaAtomShape()); // B frags per sub_group
@@ -265,15 +289,18 @@ public:
     // Indexing variables
     auto [M, N, K, L] = problem_shape_mnkl;
     auto [m_coord, n_coord, k_coord, l_coord] = tile_coord_mnkl;
+    auto m_offset = m_coord * BLK_M + (get_sub_group_id() / ATOM_N) * SG_M;
+    auto n_offset = n_coord * BLK_N + (get_sub_group_id() % ATOM_N) * SG_N;
+    auto l_offset = l_coord;
 
     bool is_C_load_needed = is_source_supported && fusion_callbacks.is_C_load_needed();
 
     Tensor trC = make_tensor<typename TiledMma::ValTypeC>(Shape<Int<FragmentSize>>{});
     Tensor trD = make_tensor<typename TiledMma::ValTypeD>(Shape<Int<FragmentSize>>{});
     Tensor tOuti = params.xe_store_d.get_pvc_tensor(
-            make_coord(m_coord, n_coord, 0),
-            make_shape(Int<FragsM>{}, Int<FragsN>{}, L),
-            make_stride(Int<get<0>(MmaAtomShape{})>{}, Int<get<1>(MmaAtomShape{})>{}));
+            make_coord(m_offset, n_offset, l_offset),
+            make_shape(_, Int<FragsM>{}, Int<FragsN>{}, L),
+            make_stride(Int<get<0>(MmaAtomShape{})>{}, Int<get<1>(MmaAtomShape{})>{}, _1{}));
 
     Tensor rw_coord = tOuti(_,_,_,l_coord);
     Tensor mD_crd = make_identity_tensor(make_shape(M,N));
@@ -324,7 +351,6 @@ public:
     }
 
     cst_callbacks.end();
-
   }
 
 private:

--- a/include/cutlass/gemm/collective/intel_pvc_mma.hpp
+++ b/include/cutlass/gemm/collective/intel_pvc_mma.hpp
@@ -101,24 +101,35 @@ struct CollectiveMma<
   static constexpr int SubgroupSize = DispatchPolicy::SubgroupSize;
 
   using MmaAtomShape = typename TiledMma::AtomShape_MNK;
-  using SubgroupTileShape = decltype(tile_shape(TiledMma()));
 
-  static constexpr auto sg_per_wg_m = get<0>(WorkgroupTileShape{}) / get<0>(SubgroupTileShape{});
-  static constexpr auto sg_per_wg_n = get<1>(WorkgroupTileShape{}) / get<1>(SubgroupTileShape{});
+  static constexpr auto BLK_M = get<0>(WorkgroupTileShape{});
+  static constexpr auto BLK_N = get<1>(WorkgroupTileShape{});
+  static constexpr auto BLK_K = get<2>(WorkgroupTileShape{});
+  
+  static constexpr auto ATOM_M = get<1>(typename TiledMma::ThrLayoutVMNK{}.shape());
+  static constexpr auto ATOM_N = get<2>(typename TiledMma::ThrLayoutVMNK{}.shape());
+  static constexpr auto ATOM_K = get<3>(typename TiledMma::ThrLayoutVMNK{}.shape());
 
-  static constexpr uint32_t MaxThreadsPerBlock =
-          cute::size(WorkgroupTileShape{}) / cute::size(SubgroupTileShape{}) * SubgroupSize;
-
-  static constexpr int FragsM = get<0>(SubgroupTileShape{}) / get<0>(MmaAtomShape()); // A frags per sub_group
-  static constexpr int FragsN = get<1>(SubgroupTileShape{}) / get<1>(MmaAtomShape()); // B frags per sub_group
-  static constexpr int FragsK = get<2>(SubgroupTileShape{}) / get<2>(MmaAtomShape());
-
-  // Calculate the vector width based on the amount of registers 
-  // required per work item by dividing the total fragment size by 
-  // the sub_group size.
-  static constexpr int VecC = (get<1>(MmaAtomShape()) * get<0>(MmaAtomShape())) / SubgroupSize;
-  static constexpr int VecA = (get<0>(MmaAtomShape()) * get<2>(MmaAtomShape())) / SubgroupSize;
-  static constexpr int VecB = (get<1>(MmaAtomShape()) * get<2>(MmaAtomShape())) / SubgroupSize;
+  static constexpr auto SG_M = ceil_div(BLK_M, ATOM_M);
+  static constexpr auto SG_N = ceil_div(BLK_N, ATOM_N);
+  static constexpr auto SG_K = ceil_div(BLK_K, ATOM_K);
+  using SubgroupTileShape = Shape<decltype(SG_M), decltype(SG_N), decltype(SG_K)>;
+  
+  static constexpr uint32_t MaxThreadsPerBlock = size(TiledMma{});
+  using traits_load_A = Copy_Traits<GmemTiledCopyA>;
+  using atom_load_A = Copy_Atom<traits_load_A, ElementA>;
+  using XE_Copy_A = decltype(make_tiled_copy(atom_load_A{}
+                                            .with(static_cast<ElementA const*>(nullptr), int32_t(0), int32_t(0), int32_t(0)), 
+                                            Layout<Shape<_1, Int<SubgroupSize>>>{},
+                                            make_layout(make_shape(get<0>(typename traits_load_A::Shape_MN{}),
+                                                                   get<1>(typename traits_load_A::Shape_MN{}) / Int<SubgroupSize>{}))));
+  using traits_load_B = Copy_Traits<GmemTiledCopyB>;
+  using atom_load_B = Copy_Atom<traits_load_B, ElementB>;
+  using XE_Copy_B = decltype(make_tiled_copy(atom_load_B{}
+                                            .with(static_cast<ElementB const*>(nullptr), int32_t(0), int32_t(0), int32_t(0)),
+                                            Layout<Shape<_1, Int<SubgroupSize>>>{},
+                                            make_layout(make_shape(get<0>(typename traits_load_B::Shape_MN{}),
+                                                                   get<1>(typename traits_load_B::Shape_MN{}) / Int<SubgroupSize>{}))));
 
   // Host side kernel arguments
   struct Arguments {
@@ -129,10 +140,7 @@ struct CollectiveMma<
   };
 
   struct Params {
-    using XE_Copy_A = decltype(make_xe_2d_copy<GmemTiledCopyA>(make_tensor(static_cast<ElementA const*>(nullptr), 
-                                repeat_like(StrideA{}, int32_t(0)), StrideA{})));
-    using XE_Copy_B = decltype(make_xe_2d_copy<GmemTiledCopyB>(make_tensor(static_cast<ElementB const*>(nullptr), 
-                                repeat_like(StrideB{}, int32_t(0)), StrideB{})));
+    Arguments args;
     XE_Copy_A gmem_tiled_copy_a;
     XE_Copy_B gmem_tiled_copy_b;
   };
@@ -151,12 +159,15 @@ struct CollectiveMma<
     auto problem_shape_MNKL = append<4>(problem_shape, 1);
     auto [M,N,K,L] = problem_shape_MNKL;
 
-    Tensor tensorA = make_tensor(args.ptr_A, make_layout(make_shape(M,K,L), args.dA));
-    Tensor tensorB = make_tensor(args.ptr_B, make_layout(make_shape(N,K,L), args.dB));
-
-    typename Params::XE_Copy_A copyA = make_xe_2d_copy<GmemTiledCopyA>(tensorA);
-    typename Params::XE_Copy_B copyB = make_xe_2d_copy<GmemTiledCopyB>(tensorB);
-    return Params{copyA, copyB};
+    XE_Copy_A copyA = make_tiled_copy(Copy_Atom<Copy_Traits<GmemTiledCopyA>, ElementA>{}.with(args.ptr_A, K, M, K),
+                                      Layout<Shape<_1, Int<SubgroupSize>>>{},
+                                      make_layout(make_shape(get<0>(typename traits_load_A::Shape_MN{}),
+                                                             get<1>(typename traits_load_A::Shape_MN{}) / Int<SubgroupSize>{})));
+    XE_Copy_B copyB = make_tiled_copy(Copy_Atom<Copy_Traits<GmemTiledCopyB>, ElementB>{}.with(args.ptr_B, N, K, N),
+                                      Layout<Shape<_1, Int<SubgroupSize>>>{},
+                                      make_layout(make_shape(get<0>(typename traits_load_B::Shape_MN{}),
+                                                             get<1>(typename traits_load_B::Shape_MN{}) / Int<SubgroupSize>{})));
+    return Params{args, copyA, copyB};
   }
 
   /// Perform a subgroup-scoped matrix multiply-accumulate
@@ -184,72 +195,79 @@ struct CollectiveMma<
     (void)thread_idx;
     (void)smem_buf;
 
-    static_assert(is_rmem<FrgTensorD>::value, "D tensor must be rmem resident.");
-    static_assert(is_tuple<typename TensorA::engine_type::iterator::value_type>::value, "A tensor must be a tuple iterator.");
-    static_assert(is_tuple<typename TensorB::engine_type::iterator::value_type>::value, "B tensor must be a tuple iterator.");
-    static_assert(is_rmem<FrgTensorC>::value, "C tensor must be rmem resident.");
-
-    // Tensor to hold input data
-    constexpr int version =
-        is_same_v<GmemTiledCopyB, XE_2D_U16x16x16x2x1_V> ? 1 : 2;
-
-    Tensor tAr = make_tensor<typename TiledMma::ValTypeA>(Shape<Int<get<0>(SubgroupTileShape{}) * FragsK>, Int<1>>{});
-    Tensor tBr = make_tensor<typename TiledMma::ValTypeB>(Shape<Int<get<2>(SubgroupTileShape{}) * version>, Int<FragsN / version>>{});
-
-    Tensor tAr_view = make_tensor(static_cast<decltype(tAr) &&>(tAr).data(),
-                            Shape<Int<VecA>, Int<FragsM>, Int<FragsK>>{});
-    Tensor tBr_view = make_tensor(static_cast<decltype(tBr) &&>(tBr).data(),
-                            Shape<Int<VecB>, Int<FragsN>, Int<FragsK>>{},
-                            Stride<_1, Int<VecB * FragsK>, Int<VecB>>{});
-
-    // Instantiate the M MA object
+    // Instantiate the MMA object
     TiledMma tiled_mma;
+    auto thread_mma = tiled_mma.get_slice(thread_idx);
+    Tensor tCrA_partition = thread_mma.partition_fragment_A(gA(_, _, 0));
+    Tensor tCrA = make_tensor(static_cast<decltype(tCrA_partition) &&>(tCrA_partition).data(),
+                              tCrA_partition.shape());
+    Tensor tCrB_partition = thread_mma.partition_fragment_B(gB(_, _, 0));
+    Tensor tCrB = make_tensor(static_cast<decltype(tCrB_partition) &&>(tCrB_partition).data(),
+                              make_shape(size<0>(tCrB_partition.shape()),
+                                         size<2>(tCrB_partition.shape()),
+                                         size<1>(tCrB_partition.shape())));
+    // Partition the copying of A and B tiles across the threads
+    auto gmem_thr_copy_A = mainloop.gmem_tiled_copy_a.get_slice(thread_idx);
+    auto gmem_thr_copy_B = mainloop.gmem_tiled_copy_b.get_slice(thread_idx);
 
-    int K = size<1>(mainloop.gmem_tiled_copy_a.tensor);
+    auto tCrA_copy_view = gmem_thr_copy_A.retile_D(tCrA);
+    auto tCrB_copy_view = gmem_thr_copy_B.retile_D(tCrB);
 
-    auto sub_group_id = ThreadIdxX() / SubgroupSize;
-    /* Cooperative prefetch
-       Divice the thread space to sg_per_wg_m x sg_per_wg_n, all the threads in one row/col use the same tile A/B. 
-       Each thread loads sizeof(tile A or B) / numof(sg_per_wg_n or sg_per_wg_m). 
-       
-       Currently, sg_per_wg_m x sg_per_wg_n = 4 x 8 is the most efficient
-    */
-    // TODO: Replace the demo cooperative prefetch with more general way.
-    Tensor tAi = make_tensor(
-        make_inttuple_iter(
-            *gA.data() +
-            make_coord((sub_group_id % sg_per_wg_n % 4) * get<0>(MmaAtomShape{}), 0)),
-        make_layout(make_shape(_1{}, _1{}, K),
-                    make_stride(_1{}, E<0>{}, E<1>{})));
-    Tensor tBi = make_tensor(
-        make_inttuple_iter(
-            *gB.data() +
-            make_coord((sub_group_id / sg_per_wg_n % 2 * 2) * get<1>(MmaAtomShape{}),
-                       (sub_group_id / sg_per_wg_n / 2 % 2) * get<2>(MmaAtomShape{}))),
-        make_layout(make_shape(_1{}, _1{}, K),
-                    make_stride(_1{}, E<0>{}, E<1>{})));
+  #if CUTLASS_ENABLE_DEBUG_PRINTS
+    if (thread(LOG_THREAD, LOG_GROUP)) {
+        print("======================= A: \n");
+        print("  gA : "); print(gA); print("\n");
+        print("tCrA_copy_view : "); print(tCrA_copy_view); print("\n");
+        print("  tCrA : "); print(tCrA); print("\n");
+
+        print("=====================  B :\n");
+        print("  gB : "); print(gB); print("\n");
+        print("tCrB_copy_view : "); print(tCrB_copy_view); print("\n");
+        print("  tCrB : "); print(tCrB); print("\n");
+
+        print("=====================  Config: \n");
+        print("  threads per workgroup : "); print(MaxThreadsPerBlock); print("\n");
+        print("  SubgroupTileShape : "); print(SubgroupTileShape{}); print("\n");
+      }
+    #endif
+
     //
     // Mainloop
     //
-    int prefetch_k = 0;
-
+    const int m_coord = BlockIdxX() * BLK_M + (get_sub_group_id() / ATOM_N) * SG_M;
+    const int n_coord = BlockIdxY() * BLK_N + (get_sub_group_id() % ATOM_N) * SG_N;
+    const int l_coord = BlockIdxZ();
+    Tensor iter_a = mainloop.gmem_tiled_copy_a.get_pvc_tensor(
+      make_coord(m_coord, 0, l_coord), append<4>(tCrA_copy_view.shape(), k_tile_count),
+      append<3>(typename XE_Copy_A::Shape_MN{}, BLK_K), seq<0,1,1>{});
+    Tensor iter_b = mainloop.gmem_tiled_copy_b.get_pvc_tensor(
+      make_coord(0, n_coord, l_coord), append<4>(tCrB_copy_view.shape(), k_tile_count),
+      append<3>(typename XE_Copy_B::Shape_MN{}, BLK_K), seq<0,1,0>{});
+#pragma unroll
     for (int i = 0; i < DispatchPolicy::Stages; i++) {
-      prefetch(mainloop.gmem_tiled_copy_a, tAi(_, _, prefetch_k));
-      prefetch(mainloop.gmem_tiled_copy_b, tBi(_, _, prefetch_k));
-      prefetch_k += get<2>(SubgroupTileShape{});
+      if constexpr(cute::detail::has_prefetch<GmemTiledCopyA>) {
+        prefetch(mainloop.gmem_tiled_copy_a, iter_a(_,_,_,i));
+      }
+      if constexpr(cute::detail::has_prefetch<GmemTiledCopyB>) {
+        prefetch(mainloop.gmem_tiled_copy_b, iter_b(_,_,_,i));  
+      }
     }
-
-    for (int k_tile = 0, k = 0; k_tile < k_tile_count;
-         ++k_tile, k += get<2>(SubgroupTileShape{})) {
+#pragma unroll
+    for (int k_tile = 0; k_tile < k_tile_count; ++k_tile) {
       // Copy gmem to rmem for the first k_tile
-      copy(mainloop.gmem_tiled_copy_a, gA(_, _, k), tAr);
-      copy(mainloop.gmem_tiled_copy_b, gB(_, _, k), tBr);
-
-      prefetch(mainloop.gmem_tiled_copy_a, tAi(_, _, prefetch_k));
-      prefetch(mainloop.gmem_tiled_copy_b, tBi(_, _, prefetch_k));
-      prefetch_k += get<2>(SubgroupTileShape{});
-
-      cute::gemm(tiled_mma, accum, tAr_view, tBr_view, src_accum);
+      copy(mainloop.gmem_tiled_copy_a, iter_a(_,_,_,k_tile), tCrA_copy_view);
+      copy(mainloop.gmem_tiled_copy_b, iter_b(_,_,_,k_tile), tCrB_copy_view);
+    if(k_tile + DispatchPolicy::Stages < k_tile_count) {
+      if constexpr(cute::detail::has_prefetch<GmemTiledCopyA>) {
+        prefetch(mainloop.gmem_tiled_copy_a, iter_a(_,_,_,k_tile + DispatchPolicy::Stages));
+      }
+      if constexpr(cute::detail::has_prefetch<GmemTiledCopyB>) {
+        prefetch(mainloop.gmem_tiled_copy_b, iter_b(_,_,_,k_tile + DispatchPolicy::Stages));  
+      }
+    }
+    for (int i = 0; i < SG_K / SubgroupSize; i++) {
+      cute::gemm(tiled_mma, accum, tCrA(_, _, i), tCrB(_, i, _), src_accum);
+    }
     }
   }
 };

--- a/include/cutlass/gemm/kernel/intel_pvc_gemm.hpp
+++ b/include/cutlass/gemm/kernel/intel_pvc_gemm.hpp
@@ -105,11 +105,6 @@ public:
   using MmaAtomShape = typename CollectiveMainloop::MmaAtomShape;
   using SubgroupTileShape = typename CollectiveMainloop::SubgroupTileShape;
 
-  static constexpr int FragsM = CollectiveMainloop::FragsM;
-  static constexpr int FragsN = CollectiveMainloop::FragsN;
-
-  static constexpr int VecC = CollectiveMainloop::VecC;
-
   // Kernel level shared memory storage
   struct SharedStorage {
     using EpilogueTensorStorage = typename CollectiveEpilogue::TensorStorage;
@@ -211,28 +206,22 @@ public:
 
     // Get the appropriate blocks for this sub_group -- potential for sub_group locality
     int thread_idx = int(ThreadIdxX());
+    auto blk_shape = TileShape{};
+    auto m_coord = BlockIdxX();
+    auto n_coord = BlockIdxY();
+    auto l_coord = BlockIdxZ();
+    auto blk_coord_mnkl = make_coord(m_coord, n_coord, _, l_coord);  
     int sub_group_id = thread_idx / SubgroupSize;
     constexpr auto workgroup_shape = WorkgroupTileShape{};                                                  // (SUB_M,SUB_N,SUB_K)
-    constexpr auto subgroup_shape = SubgroupTileShape{};                                                  // (SUB_M,SUB_N,SUB_K)
-    const int m_coord = BlockIdxY() * get<0>(workgroup_shape) + sub_group_id / CollectiveMainloop::sg_per_wg_n * get<0>(subgroup_shape);
-    const int n_coord = BlockIdxX() * get<1>(workgroup_shape) + sub_group_id % CollectiveMainloop::sg_per_wg_n * get<1>(subgroup_shape);
-    const int l_coord = BlockIdxZ();
-    const auto tile_coord = make_coord(m_coord, n_coord, _, l_coord);
+    constexpr auto subgroup_shape = SubgroupTileShape{};                   
+    
+    Tensor mA_mkl = make_tensor(make_gmem_ptr(params.mainloop.args.ptr_A), make_shape(M,K,L), (params.mainloop.args.dA)); //(m,k,l)
+    Tensor mB_nkl = make_tensor(make_gmem_ptr(params.mainloop.args.ptr_B), make_shape(N,K,L), (params.mainloop.args.dB)); //(n,k,l)
+    Tensor mA_mk = mA_mkl(_,_,l_coord);                                                                        // (m,k)
+    Tensor mB_nk = mB_nkl(_,_,l_coord);                                                                        // (n,k)
 
-    Tensor tAi = params.mainloop.gmem_tiled_copy_a.get_pvc_tensor(
-            make_coord(m_coord, 0, 0),
-            make_shape(_1{}, K, L),
-            make_stride(Int<FragsM>{} * get<0>(MmaAtomShape()),_1{}));
-    constexpr int version =
-        is_same_v<typename CollectiveMainloop::GmemTiledCopyB,
-                  XE_2D_U16x16x16x2x1_V>
-            ? 1
-            : 2;
-
-    Tensor tBi = params.mainloop.gmem_tiled_copy_b.get_pvc_tensor(
-            make_coord(n_coord, 0, 0),
-            make_shape(Int<FragsN / version>{}, K, L),
-            make_stride(Int<version * get<1>(MmaAtomShape())>{}, _1{}));
+    auto gA = local_tile(mA_mk, blk_shape, take<0, 3>(blk_coord_mnkl), Step<_1,  X, _1>{});
+    auto gB = local_tile(mB_nk, blk_shape, take<0, 3>(blk_coord_mnkl), Step< X, _1, _1>{});
 
     // Compute tile residues for predication
     auto m_max_coord = M - get<0>(subgroup_shape) * m_coord;                             // M - SUB_M * m_coord
@@ -243,18 +232,18 @@ public:
     // Allocate the tiled_mma and the accumulators for the (M,N) subgroup_shape
     TiledMma tiled_mma;
 
-    Tensor accumulators = make_tensor<ElementAccumulator>(Shape<Int<VecC>, Int<FragsM>, Int<FragsN>>{});
+    Tensor accumulators = partition_fragment_C(tiled_mma, take<0,2>(blk_shape)); 
     clear(accumulators);
 
-    auto k_tile_iter  = cute::make_coord_iterator(make_shape(K / get<2>(subgroup_shape)));
-    int  k_tile_count = K / get<2>(subgroup_shape);
+    auto k_tile_iter  = cute::make_coord_iterator(make_shape(K / get<2>(workgroup_shape)));
+    int  k_tile_count = K / get<2>(workgroup_shape);
 
     // Perform the collective scoped MMA
     CollectiveMainloop collective_mma;
     collective_mma(
       accumulators,
-      tAi(_,_,_,l_coord),
-      tBi(_,_,_,l_coord),
+      gA,
+      gB,
       accumulators,
       k_tile_iter, k_tile_count,
       residue_mnk,
@@ -267,7 +256,7 @@ public:
     epilogue(
       problem_shape_MNKL,
       subgroup_shape,
-      tile_coord,
+      blk_coord_mnkl,
       accumulators,
       tiled_mma,
       residue_mnk,


### PR DESCRIPTION
1. 
```
using TiledMma = TiledMMA<MMA_Atom<XE_8x16x16_F32BF16BF16F32_TT>,
                               Layout<Shape<_8,_2,_1>>,
                               Tile<Underscore,Underscore,Underscore>>; // Subgroup level-tile
```
this type should be dedicatedly designed to meet the `Copy_A` and `Copy_B` especially  `PermuteMNK` 
2. The original verification use `GemmComplex` launched on device to calculate the reference tensor and compare it with the result tensor. But I can guarantee they are totally same
3.  
 ```
using GmemTiledCopyA = XE_2D_U16x32x32_LD_N;
using GmemTiledCopyB = XE_2D_U16x32x32_LD_V;
```
4K x 4K x4K gemm can reach 240 tflops currently 