### PR TITLE
track SLM copy

### DIFF
--- a/examples/cute/tutorial/CMakeLists.txt
+++ b/examples/cute/tutorial/CMakeLists.txt
@@ -61,6 +61,11 @@ if (CUTLASS_ENABLE_SYCL)
       cute_tutorial_xe_gemm
       xe_gemm.cpp
     )
+
+    cutlass_example_add_executable(
+      cute_tutorial_SLM_copy
+      SLM_copy.cpp
+    )
   endif()
 
   if (SYCL_NVIDIA_TARGET)

--- a/examples/cute/tutorial/SLM_copy.cpp
+++ b/examples/cute/tutorial/SLM_copy.cpp
@@ -53,6 +53,8 @@
 #elif defined(__GNUC__)
   #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 #endif
+
+#define PRINT(x) print(#x ": "); print(x); print("\n");
 template<class...> class CopyKernelGlobalName;
 
 using namespace cute;
@@ -65,7 +67,7 @@ void copy_kernel_ocl(TensorS S, CtaTiler cta_tiler, SmemLayout smem_layout, Thre
 
 //   auto cta_coord = make_coord(compat::work_group_id::x(), compat::work_group_id::y(), _);
   
-  using traits_load = Copy_Traits<XE_2D_U32x8x16_LD_N, decltype(S)>;
+  using traits_load = Copy_Traits<XE_2D_U32x16x16_LD_N, decltype(S)>;
   using Atom_load = Copy_Atom<traits_load, Element>;
   auto tiled_copy_load = make_tiled_copy(Atom_load{}.with(S),
                                          Layout<Shape<_1, _16>>{},
@@ -74,28 +76,27 @@ void copy_kernel_ocl(TensorS S, CtaTiler cta_tiler, SmemLayout smem_layout, Thre
   auto S_coord = cute::get_xe_tensor(append(S.shape(),_1{}))(_,_,0);
 
   Tensor tiled_tensor_S = tiled_divide(
-    S_coord, select<0,2>(cta_tiler)); // ((M, N), m', n')
+    S_coord, select<0,1>(cta_tiler)); // ((M, N), m', n')
   // Slice work group.
   Tensor tile_wg_S = tiled_tensor_S(make_coord(_, _), BlockIdxX(), BlockIdxY());
   
   auto thr_copy_load =
       tiled_copy_load.get_thread_slice(cutlass::get_sub_group_local_id());
-  auto SubgroupShape = Shape<_16, _16>{};
+  auto SubgroupShape = make_shape(ceil_div(get<0>(cta_tiler), get<0>(t_layout.shape())), 
+                                  ceil_div(get<1>(cta_tiler), get<1>(t_layout.shape()) / _16{}));
   auto sg_id = cutlass::get_sub_group_id();
   Tensor tile_sg_S = local_tile(tile_wg_S, SubgroupShape, sg_id);
   Tensor thr_tile_load_S = thr_copy_load.partition_S(tile_sg_S);
   Tensor thr_tile_load_D = thr_copy_load.partition_D(tile_sg_S);
   Tensor fragment = make_tensor<Element>(thr_tile_load_D.shape());
 #if 0
-  #define PRINT(x) print(#x ": "); print(x); print("\n");
   if(cute::thread0()) {
     PRINT(tiled_tensor_S);
     PRINT(fragment);
     PRINT(tile_wg_S);
+    PRINT(thr_tile_load_S);
   }
 #endif
-  
-  int k_tile_count = size<1>(thr_tile_load_S);
 
   copy(tiled_copy_load, thr_tile_load_S, fragment);
 
@@ -108,26 +109,25 @@ void copy_kernel_vector(TensorS S, CtaTiler cta_tiler, SmemLayout smem_layout, T
   using Element = typename TensorS::value_type;
   auto smem = compat::local_mem<Element[cosize_v<SmemLayout>]>();
 
-//   auto cta_coord = make_coord(compat::work_group_id::x(), compat::work_group_id::y(), _);
-  
-  using COPY_ATOM = XE_LOAD_2D<sizeof_bits_v<Element>, 16, 16>;
+  using COPY_ATOM = XE_LOAD_2D<sizeof_bits_v<Element>, 8, 16>;
+  auto SgV = make_layout(make_shape(Shape<_8, _4>{}, Shape<_8, Shape<_8, _2>>{}),
+                       make_stride(Stride<_8192,_64>{}, Stride<_1, Stride<_8, _4096>>{}));
   auto copy_global = make_block_2d_copy_X<Element>(COPY_ATOM{}, S.stride(),
                         find_x_mode(S.stride()), find_y_mode(S.stride()),
-                        make_tile(_32{}, _256{}),
-                        Layout<Shape<_2, _16>>{}).with(S);
+                        make_tile(get<0>(cta_tiler), get<1>(cta_tiler)),
+                        SgV).with(S);
 
   auto thr_copy_global = copy_global.get_slice(compat::local_id::x());
   /* Create proxy coordinate tensors for each global tensor */
-  Tensor cC = make_identity_tensor(S.shape());   // (M,K)
-  Tensor gS = local_tile(cC, select<0,2>(cta_tiler), make_coord(compat::work_group_id::x(),_));  // (BLK_M,BLK_K,k)
-  Tensor sD = make_tensor(make_smem_ptr(smem), smem_layout);          // (BLK_M,BLK_K,stages)
+  Tensor cC = make_identity_tensor(S.shape());   // (M,N)
+  Tensor gS = local_tile(cC, select<0,1>(cta_tiler), make_coord(compat::work_group_id::x(),compat::work_group_id::y()));  // (BLK_M,BLK_N)
+  Tensor sD = make_tensor(make_smem_ptr(smem), smem_layout);          // (BLK_M,BLK_N,stages)
   /* Register fragments for copies */
-  auto trS = thr_copy_global.partition_sg_fragment_D(gS(_,_,0));
+  auto trS = thr_copy_global.partition_sg_fragment_D(gS);
   /* Partition global tensor (proxies) for copies */
   Tensor tgS = thr_copy_global.partition_S(gS);
 
 #if 0
-  #define PRINT(x) print(#x ": "); print(x); print("\n");
   if(cute::thread0()) {
     PRINT(trS);
     PRINT(tgS);
@@ -137,10 +137,7 @@ void copy_kernel_vector(TensorS S, CtaTiler cta_tiler, SmemLayout smem_layout, T
   
   int k_tile_count = ceil_div(shape<1>(S), get<2>(cta_tiler));
 
-  // #pragma unroll
-  // for(int k_tile = 0; k_tile < k_tile_count; ++k_tile) {
-    copy(copy_global, tgS(_,_,_,0), trS);
-  // }
+  copy(copy_global, tgS, trS);
 
 }
 
@@ -150,26 +147,25 @@ void copy_kernel_1d(TensorS S, CtaTiler cta_tiler, SmemLayout smem_layout, Threa
   using Element = typename TensorS::value_type;
   auto smem = compat::local_mem<Element[cosize_v<SmemLayout>]>();
 
-//   auto cta_coord = make_coord(compat::work_group_id::x(), compat::work_group_id::y(), _);
-  
-  using COPY_ATOM = XE_LOAD_2D<sizeof_bits_v<Element>, 16, 16>;
+  using COPY_ATOM = XE_LOAD_2D<sizeof_bits_v<Element>, 8, 16>;
+  auto SgV = make_layout(make_shape(Shape<_8, _4>{}, Shape<_8, Shape<_8, _2>>{}),
+                       make_stride(Stride<_8192,_64>{}, Stride<_1, Stride<_8, _4096>>{}));
   auto copy_global = make_block_2d_copy_X<Element>(COPY_ATOM{}, S.stride(),
                         find_x_mode(S.stride()), find_y_mode(S.stride()),
-                        make_tile(_32{}, _256{}),
-                        Layout<Shape<_2, _16>>{}).with(S);
+                        make_tile(get<0>(cta_tiler), get<1>(cta_tiler)),
+                        SgV).with(S);
 
   auto thr_copy_global = copy_global.get_slice(compat::local_id::x());
   /* Create proxy coordinate tensors for each global tensor */
-  Tensor cC = make_identity_tensor(S.shape());   // (M,K)
-  Tensor gS = local_tile(cC, select<0,2>(cta_tiler), make_coord(compat::work_group_id::x(),_));  // (BLK_M,BLK_K,k)
-  Tensor sD = make_tensor(make_smem_ptr(smem), smem_layout);          // (BLK_M,BLK_K,stages)
+  Tensor cC = make_identity_tensor(S.shape());   // (M,N)
+  Tensor gS = local_tile(cC, select<0,1>(cta_tiler), make_coord(compat::work_group_id::x(),compat::work_group_id::y()));  // (BLK_M,BLK_N)
+  Tensor sD = make_tensor(make_smem_ptr(smem), smem_layout);          // (BLK_M,BLK_N,stages)
   /* Register fragments for copies */
-  auto trS = thr_copy_global.partition_sg_fragment_D(gS(_,_,0));
+  auto trS = thr_copy_global.partition_sg_fragment_D(gS);
   /* Partition global tensor (proxies) for copies */
   Tensor tgS = thr_copy_global.partition_S(gS);
 
 #if 0
-  #define PRINT(x) print(#x ": "); print(x); print("\n");
   if(cute::thread0()) {
     PRINT(trS);
     PRINT(tgS);
@@ -179,11 +175,7 @@ void copy_kernel_1d(TensorS S, CtaTiler cta_tiler, SmemLayout smem_layout, Threa
   
   int k_tile_count = ceil_div(shape<1>(S), get<2>(cta_tiler));
 
-  #pragma unroll
-  for(int k_tile = 0; k_tile < k_tile_count; ++k_tile) {
-    copy(copy_global, tgS(_,_,_,k_tile), trS);
-  }
-
+  copy(copy_global, tgS, trS);
 }
 
 template<class TensorS, class CtaTiler, class SmemLayout, class ThreadLayout>
@@ -193,57 +185,52 @@ void copy_kernel_naive(TensorS S, CtaTiler cta_tiler, SmemLayout smem_layout, Th
   auto smem = compat::local_mem<Element[cosize_v<SmemLayout>]>();
 
   auto cta_coord = make_coord(compat::work_group_id::x(), compat::work_group_id::y(), _);
-  Tensor gS = local_tile(S, cta_tiler, cta_coord, Step<_1, X,_1>{});  // (BLK_M,BLK_K,k)
-  Tensor sD = make_tensor(make_smem_ptr(smem), smem_layout);          // (BLK_M,BLK_K,stages)
+  Tensor gS = local_tile(S, cta_tiler, cta_coord, Step<_1, _1, X>{});  // (BLK_M,BLK_N)
+  Tensor sD = make_tensor(make_smem_ptr(smem), smem_layout);          // (BLK_M,BLK_N,stages)
 
-  Tensor tgS = local_partition(gS, t_layout, compat::local_id::x());   // (THR_M,THR_N,k)
+  Tensor tgS = local_partition(gS, t_layout, compat::local_id::x());   // (THR_M,THR_N)
   Tensor tsD = local_partition(sD, t_layout, compat::local_id::x());   // (THR_M,THR_N,stages)
 
-  auto K_TILE_MAX = size<2>(tgS);
+  // auto K_TILE_MAX = size<2>(tgS);
   constexpr auto stages = size<2>(tsD);
-  
-  #pragma unroll
-  for(int k_tile = 0; k_tile < K_TILE_MAX; ++k_tile) {
-    copy(tgS(_, _, k_tile), tsD(_, _, k_tile % stages));
-    compat::wg_barrier();// Wait for all threads to write to smem
-  }
-  
+
+  copy(tgS, tsD(_, _, 0));
+  compat::wg_barrier();
+
 #if 0
-#define PRINT(x) print(#x ": "); print(x); print("\n");
   if(cute::thread0()) {
     PRINT(tgS);
-    PRINT(tsD);
   }
 #endif
 
 }
 
 int main(int argc, char** argv) {
-  constexpr int M = 4096;
-  constexpr int K = 4096 * 16;
+  constexpr uint M = 256*5;
+  constexpr uint N = 256*4;
 
   using Element = uint32_t;
 
-  std::vector<Element> host_src(M * K);
+  std::vector<Element> host_src(M * N);
 
-  for(size_t i = 0; i < M * K; ++i) {
+  for(size_t i = 0; i < M * N; ++i) {
     host_src[i] = static_cast<Element>(i);
   }
   
-  using bM = _32;
-  using bK = _256;
+  using bM = _256;
+  using bN = _256;
   using stages = _2;
-  using CtaTiler = Shape<bM, _0, bK>; 
-  auto thread_layout = Layout<Shape<_2, _128>, Stride<_128, _1>>{};
-  auto smem_layout = Layout<Shape<bM, bK, stages>, Stride<bK, _1, _8192>>{};
+  using CtaTiler = Shape<bM, bN, _0>; 
+  auto thread_layout = Layout<Shape<_4, _128>, Stride<_128, _1>>{};
+  auto smem_layout = Layout<Shape<bM, bN, stages>, Stride<bN, _1, _8192>>{};
 
-  auto device_src = compat::malloc<Element>(M * K);
-  compat::memcpy<Element>(device_src, host_src.data(), M * K);
+  auto device_src = compat::malloc<Element>(M * N);
+  compat::memcpy<Element>(device_src, host_src.data(), M * N);
   Tensor S = make_tensor(make_gmem_ptr(device_src),
-                         make_layout(make_shape(Int<M>{}, Int<K>{}), make_stride(Int<K>{}, _1{})));
+                         make_layout(make_shape(M, N), make_stride(N, _1{})));
 
   auto dimBlock = compat::dim3(size(thread_layout));
-  auto dimGrid  = compat::dim3(size(ceil_div(M, bM{})));
+  auto dimGrid  = compat::dim3(size(ceil_div(M, bM{})), size(ceil_div(N, bN{})));
   //
   // Launch the kernel
   //
@@ -252,7 +239,7 @@ int main(int argc, char** argv) {
 
   timer.start();
   for (int i = 0; i < iterations; ++i) {
-    auto event = compat::launch<copy_kernel_ocl<decltype(S), CtaTiler, decltype(smem_layout),
+    auto event = compat::launch<copy_kernel_vector<decltype(S), CtaTiler, decltype(smem_layout),
                               decltype(thread_layout)>, CopyKernelGlobalName<decltype(S), CtaTiler, decltype(smem_layout),
                               decltype(thread_layout)>>(
         dimGrid, dimBlock, S, CtaTiler{}, smem_layout, thread_layout);
@@ -261,7 +248,7 @@ int main(int argc, char** argv) {
   }
   compat::wait();
   float cute_time = timer.seconds() / iterations;
-  double io = M * K * sizeof(Element) * 1e-12;
+  double io = M * N * sizeof(Element) * 1e-12;
   printf("Performance:     [%4.3f]Gb/s  (%6.4f)ms\n", io / cute_time, cute_time*1000);
   return 0;
 }

--- a/examples/cute/tutorial/SLM_copy.cpp
+++ b/examples/cute/tutorial/SLM_copy.cpp
@@ -58,6 +58,51 @@ template<class...> class CopyKernelGlobalName;
 using namespace cute;
 
 template<class TensorS, class CtaTiler, class SmemLayout, class ThreadLayout>
+void copy_kernel_ocl(TensorS S, CtaTiler cta_tiler, SmemLayout smem_layout, ThreadLayout t_layout) {
+  static_assert(is_static<SmemLayout>::value);
+  using Element = typename TensorS::value_type;
+  auto smem = compat::local_mem<Element[cosize_v<SmemLayout>]>();
+
+//   auto cta_coord = make_coord(compat::work_group_id::x(), compat::work_group_id::y(), _);
+  
+  using traits_load = Copy_Traits<XE_2D_U32x8x16_LD_N, decltype(S)>;
+  using Atom_load = Copy_Atom<traits_load, Element>;
+  auto tiled_copy_load = make_tiled_copy(Atom_load{}.with(S),
+                                         Layout<Shape<_1, _16>>{},
+                                         make_layout(shape_div(typename traits_load::BlockShape{}, Shape<_1, _16>{})));
+
+  auto S_coord = cute::get_xe_tensor(append(S.shape(),_1{}))(_,_,0);
+
+  Tensor tiled_tensor_S = tiled_divide(
+    S_coord, select<0,2>(cta_tiler)); // ((M, N), m', n')
+  // Slice work group.
+  Tensor tile_wg_S = tiled_tensor_S(make_coord(_, _), BlockIdxX(), BlockIdxY());
+  
+  auto thr_copy_load =
+      tiled_copy_load.get_thread_slice(cutlass::get_sub_group_local_id());
+  auto SubgroupShape = Shape<_16, _16>{};
+  auto sg_id = cutlass::get_sub_group_id();
+  Tensor tile_sg_S = local_tile(tile_wg_S, SubgroupShape, sg_id);
+  Tensor thr_tile_load_S = thr_copy_load.partition_S(tile_sg_S);
+  Tensor thr_tile_load_D = thr_copy_load.partition_D(tile_sg_S);
+  Tensor fragment = make_tensor<Element>(thr_tile_load_D.shape());
+#if 0
+  #define PRINT(x) print(#x ": "); print(x); print("\n");
+  if(cute::thread0()) {
+    PRINT(tiled_tensor_S);
+    PRINT(fragment);
+    PRINT(tile_wg_S);
+  }
+#endif
+  
+  int k_tile_count = size<1>(thr_tile_load_S);
+
+  copy(tiled_copy_load, thr_tile_load_S, fragment);
+
+}
+
+
+template<class TensorS, class CtaTiler, class SmemLayout, class ThreadLayout>
 void copy_kernel_vector(TensorS S, CtaTiler cta_tiler, SmemLayout smem_layout, ThreadLayout t_layout) {
   static_assert(is_static<SmemLayout>::value);
   using Element = typename TensorS::value_type;
@@ -92,10 +137,10 @@ void copy_kernel_vector(TensorS S, CtaTiler cta_tiler, SmemLayout smem_layout, T
   
   int k_tile_count = ceil_div(shape<1>(S), get<2>(cta_tiler));
 
-  #pragma unroll
-  for(int k_tile = 0; k_tile < k_tile_count; ++k_tile) {
-    copy(copy_global, tgS(_,_,_,k_tile), trS);
-  }
+  // #pragma unroll
+  // for(int k_tile = 0; k_tile < k_tile_count; ++k_tile) {
+    copy(copy_global, tgS(_,_,_,0), trS);
+  // }
 
 }
 
@@ -174,8 +219,8 @@ void copy_kernel_naive(TensorS S, CtaTiler cta_tiler, SmemLayout smem_layout, Th
 }
 
 int main(int argc, char** argv) {
-  int M = 4096;
-  int K = 4096 * 16;
+  constexpr int M = 4096;
+  constexpr int K = 4096 * 16;
 
   using Element = uint32_t;
 
@@ -195,7 +240,7 @@ int main(int argc, char** argv) {
   auto device_src = compat::malloc<Element>(M * K);
   compat::memcpy<Element>(device_src, host_src.data(), M * K);
   Tensor S = make_tensor(make_gmem_ptr(device_src),
-                         make_layout(make_shape(M, K), make_stride(K, _1{})));
+                         make_layout(make_shape(Int<M>{}, Int<K>{}), make_stride(Int<K>{}, _1{})));
 
   auto dimBlock = compat::dim3(size(thread_layout));
   auto dimGrid  = compat::dim3(size(ceil_div(M, bM{})));
@@ -207,7 +252,7 @@ int main(int argc, char** argv) {
 
   timer.start();
   for (int i = 0; i < iterations; ++i) {
-    auto event = compat::launch<copy_kernel_naive<decltype(S), CtaTiler, decltype(smem_layout),
+    auto event = compat::launch<copy_kernel_ocl<decltype(S), CtaTiler, decltype(smem_layout),
                               decltype(thread_layout)>, CopyKernelGlobalName<decltype(S), CtaTiler, decltype(smem_layout),
                               decltype(thread_layout)>>(
         dimGrid, dimBlock, S, CtaTiler{}, smem_layout, thread_layout);

--- a/examples/cute/tutorial/SLM_copy.cpp
+++ b/examples/cute/tutorial/SLM_copy.cpp
@@ -160,6 +160,7 @@ void copy_kernel_naive(TensorS S, CtaTiler cta_tiler, SmemLayout smem_layout, Th
   #pragma unroll
   for(int k_tile = 0; k_tile < K_TILE_MAX; ++k_tile) {
     copy(tgS(_, _, k_tile), tsD(_, _, k_tile % stages));
+    compat::wg_barrier();// Wait for all threads to write to smem
   }
   
 #if 0
@@ -174,7 +175,7 @@ void copy_kernel_naive(TensorS S, CtaTiler cta_tiler, SmemLayout smem_layout, Th
 
 int main(int argc, char** argv) {
   int M = 4096;
-  int K = 4096 * 4;
+  int K = 4096 * 16;
 
   using Element = uint32_t;
 

--- a/examples/cute/tutorial/SLM_copy.cpp
+++ b/examples/cute/tutorial/SLM_copy.cpp
@@ -56,8 +56,6 @@
 template<class...> class CopyKernelGlobalName;
 
 using namespace cute;
-namespace syclex = sycl::ext::oneapi::experimental;
-namespace intelex = sycl::ext::intel::experimental;
 // template <class TensorS, class TensorD, class TiledCopy>
 // void copy_kernel_SLM(TensorS S, TensorD D, TiledCopy Op) {
 //   // Shared memory buffers
@@ -66,6 +64,46 @@ namespace intelex = sycl::ext::intel::experimental;
 //   auto thr_copy_load = load.get_thread_slice(ThreadIdxX());
 //   Tensor thr_tile_load_S = 
 // }
+
+template<class TensorS, class CtaTiler, class SmemLayout, class ThreadLayout>
+void copy_kernel_vector(TensorS S, CtaTiler cta_tiler, SmemLayout smem_layout, ThreadLayout t_layout) {
+  static_assert(is_static<SmemLayout>::value);
+  using Element = typename TensorS::value_type;
+  auto smem = compat::local_mem<Element[cosize_v<SmemLayout>]>();
+
+//   auto cta_coord = make_coord(compat::work_group_id::x(), compat::work_group_id::y(), _);
+  
+  using COPY_ATOM = XE_LOAD_2D<sizeof_bits_v<Element>, 16, 16>;
+  auto copy_global = make_block_2d_copy_X<Element>(COPY_ATOM{}, S.stride(),
+                        find_x_mode(S.stride()), find_y_mode(S.stride()),
+                        make_tile(_32{}, _256{}),
+                        Layout<Shape<_2, _16>>{}).with(S);
+
+  auto thr_copy_global = copy_global.get_slice(compat::local_id::x());
+  /* Create proxy coordinate tensors for each global tensor */
+  Tensor cC = make_identity_tensor(S.shape());   // (M,K)
+  Tensor gS = local_tile(cC, select<0,2>(cta_tiler), make_coord(compat::work_group_id::x(),_));  // (BLK_M,BLK_K,k)
+  Tensor sD = make_tensor(make_smem_ptr(smem), smem_layout);          // (BLK_M,BLK_K,stages)
+  /* Register fragments for copies */
+  auto trS = thr_copy_global.partition_sg_fragment_D(gS(_,_,0));
+  /* Partition global tensor (proxies) for copies */
+  Tensor tgS = thr_copy_global.partition_S(gS);
+
+#if 0
+  #define PRINT(x) print(#x ": "); print(x); print("\n");
+  if(cute::thread0()) {
+    PRINT(trS);
+    PRINT(tgS);
+    PRINT(gS);
+  }
+#endif
+  
+  int k_tile_count = ceil_div(shape<1>(S), get<2>(cta_tiler));
+  for(int k_tile = 0; k_tile < k_tile_count; ++k_tile) {
+    copy(copy_global, tgS(_,_,_,k_tile), trS);
+  }
+
+}
 
 template<class TensorS, class CtaTiler, class SmemLayout, class ThreadLayout>
 void copy_kernel_naive(TensorS S, CtaTiler cta_tiler, SmemLayout smem_layout, ThreadLayout t_layout) {
@@ -120,8 +158,7 @@ int main(int argc, char** argv) {
   auto device_src = compat::malloc<Element>(M * K);
   compat::memcpy<Element>(device_src, host_src.data(), M * K);
   Tensor S = make_tensor(make_gmem_ptr(device_src),
-                         make_layout(make_shape(M, K), make_stride(K, 1)));
-
+                         make_layout(make_shape(M, K), make_stride(K, _1{})));
 
   auto dimBlock = compat::dim3(size(thread_layout));
   auto dimGrid  = compat::dim3(size(ceil_div(M, bM{})));

--- a/examples/cute/tutorial/SLM_copy.cpp
+++ b/examples/cute/tutorial/SLM_copy.cpp
@@ -66,7 +66,7 @@ void copy_kernel_ocl(TensorS S, CtaTiler cta_tiler, SmemLayout smem_layout, Thre
   auto smem = compat::local_mem<Element[cosize_v<SmemLayout>]>();
 
 //   auto cta_coord = make_coord(compat::work_group_id::x(), compat::work_group_id::y(), _);
-  
+  Tensor sD = make_tensor(make_smem_ptr(smem), smem_layout);          // (BLK_M,BLK_N,stages)
   using traits_load = Copy_Traits<XE_2D_U32x16x16_LD_N, decltype(S)>;
   using Atom_load = Copy_Atom<traits_load, Element>;
   auto tiled_copy_load = make_tiled_copy(Atom_load{}.with(S),
@@ -89,6 +89,15 @@ void copy_kernel_ocl(TensorS S, CtaTiler cta_tiler, SmemLayout smem_layout, Thre
   Tensor thr_tile_load_S = thr_copy_load.partition_S(tile_sg_S);
   Tensor thr_tile_load_D = thr_copy_load.partition_D(tile_sg_S);
   Tensor fragment = make_tensor<Element>(thr_tile_load_D.shape());
+
+  
+  auto tiled_slm =
+      make_tiled_copy(Copy_Atom<UniversalCopy<uint64_t>, Element>{},
+                      t_layout,
+                      Layout<Shape<_4, _2>, Stride<_2,_1>>{});
+  auto thr_copy = tiled_slm.get_slice(ThreadIdxX());
+  Tensor thr_local_D = thr_copy.partition_D(sD(_, _, 0));
+  auto trD = make_tensor(fragment.data(), thr_local_D.layout());
 #if 0
   if(cute::thread0()) {
     PRINT(tiled_tensor_S);
@@ -99,7 +108,8 @@ void copy_kernel_ocl(TensorS S, CtaTiler cta_tiler, SmemLayout smem_layout, Thre
 #endif
 
   copy(tiled_copy_load, thr_tile_load_S, fragment);
-
+  copy(tiled_slm, trD, thr_local_D);
+  compat::wg_barrier();
 }
 
 
@@ -127,18 +137,25 @@ void copy_kernel_vector(TensorS S, CtaTiler cta_tiler, SmemLayout smem_layout, T
   /* Partition global tensor (proxies) for copies */
   Tensor tgS = thr_copy_global.partition_S(gS);
 
+  auto tiled_slm =
+      make_tiled_copy(Copy_Atom<UniversalCopy<uint64_t>, Element>{},
+                      t_layout,
+                      Layout<Shape<_4, _2>, Stride<_2,_1>>{});
+  auto thr_copy = tiled_slm.get_slice(ThreadIdxX());
+  Tensor thr_local_D = thr_copy.partition_D(sD(_, _, 0));
+  auto trD = make_tensor(trS.tensor().data(), thr_local_D.layout());
+
+  copy(copy_global, tgS, trS);
+  copy(tiled_slm, trD, thr_local_D);
+  compat::wg_barrier();
 #if 0
   if(cute::thread0()) {
     PRINT(trS);
     PRINT(tgS);
     PRINT(gS);
+    PRINT(trD);
   }
 #endif
-  
-  int k_tile_count = ceil_div(shape<1>(S), get<2>(cta_tiler));
-
-  copy(copy_global, tgS, trS);
-
 }
 
 template<class TensorS, class CtaTiler, class SmemLayout, class ThreadLayout>
@@ -206,8 +223,8 @@ void copy_kernel_naive(TensorS S, CtaTiler cta_tiler, SmemLayout smem_layout, Th
 }
 
 int main(int argc, char** argv) {
-  constexpr uint M = 256*5;
-  constexpr uint N = 256*4;
+  constexpr uint M = 256*16;
+  constexpr uint N = 256*16;
 
   using Element = uint32_t;
 
@@ -222,8 +239,10 @@ int main(int argc, char** argv) {
   using stages = _2;
   using CtaTiler = Shape<bM, bN, _0>; 
   auto thread_layout = Layout<Shape<_4, _128>, Stride<_128, _1>>{};
-  auto smem_layout = Layout<Shape<bM, bN, stages>, Stride<bN, _1, _8192>>{};
-
+  // auto smem_layout = Layout<Shape<bM, bN, stages>, Stride<bN, _1, _8192>>{};
+  auto smem_layout = composition(
+          Swizzle<2,1,3>{},
+          Layout<Shape<bM, bN, stages>, Stride<bN, _1, _8192>>{});
   auto device_src = compat::malloc<Element>(M * N);
   compat::memcpy<Element>(device_src, host_src.data(), M * N);
   Tensor S = make_tensor(make_gmem_ptr(device_src),

--- a/examples/cute/tutorial/SLM_copy.cpp
+++ b/examples/cute/tutorial/SLM_copy.cpp
@@ -56,14 +56,6 @@
 template<class...> class CopyKernelGlobalName;
 
 using namespace cute;
-// template <class TensorS, class TensorD, class TiledCopy>
-// void copy_kernel_SLM(TensorS S, TensorD D, TiledCopy Op) {
-//   // Shared memory buffers
-//   using Element = typename TensorS::value_type;
-//   auto smem = compat::local_mem<Element[size(S)]>();
-//   auto thr_copy_load = load.get_thread_slice(ThreadIdxX());
-//   Tensor thr_tile_load_S = 
-// }
 
 template<class TensorS, class CtaTiler, class SmemLayout, class ThreadLayout>
 void copy_kernel_vector(TensorS S, CtaTiler cta_tiler, SmemLayout smem_layout, ThreadLayout t_layout) {
@@ -99,6 +91,50 @@ void copy_kernel_vector(TensorS S, CtaTiler cta_tiler, SmemLayout smem_layout, T
 #endif
   
   int k_tile_count = ceil_div(shape<1>(S), get<2>(cta_tiler));
+
+  #pragma unroll
+  for(int k_tile = 0; k_tile < k_tile_count; ++k_tile) {
+    copy(copy_global, tgS(_,_,_,k_tile), trS);
+  }
+
+}
+
+template<class TensorS, class CtaTiler, class SmemLayout, class ThreadLayout>
+void copy_kernel_1d(TensorS S, CtaTiler cta_tiler, SmemLayout smem_layout, ThreadLayout t_layout) {
+  static_assert(is_static<SmemLayout>::value);
+  using Element = typename TensorS::value_type;
+  auto smem = compat::local_mem<Element[cosize_v<SmemLayout>]>();
+
+//   auto cta_coord = make_coord(compat::work_group_id::x(), compat::work_group_id::y(), _);
+  
+  using COPY_ATOM = XE_LOAD_2D<sizeof_bits_v<Element>, 16, 16>;
+  auto copy_global = make_block_2d_copy_X<Element>(COPY_ATOM{}, S.stride(),
+                        find_x_mode(S.stride()), find_y_mode(S.stride()),
+                        make_tile(_32{}, _256{}),
+                        Layout<Shape<_2, _16>>{}).with(S);
+
+  auto thr_copy_global = copy_global.get_slice(compat::local_id::x());
+  /* Create proxy coordinate tensors for each global tensor */
+  Tensor cC = make_identity_tensor(S.shape());   // (M,K)
+  Tensor gS = local_tile(cC, select<0,2>(cta_tiler), make_coord(compat::work_group_id::x(),_));  // (BLK_M,BLK_K,k)
+  Tensor sD = make_tensor(make_smem_ptr(smem), smem_layout);          // (BLK_M,BLK_K,stages)
+  /* Register fragments for copies */
+  auto trS = thr_copy_global.partition_sg_fragment_D(gS(_,_,0));
+  /* Partition global tensor (proxies) for copies */
+  Tensor tgS = thr_copy_global.partition_S(gS);
+
+#if 0
+  #define PRINT(x) print(#x ": "); print(x); print("\n");
+  if(cute::thread0()) {
+    PRINT(trS);
+    PRINT(tgS);
+    PRINT(gS);
+  }
+#endif
+  
+  int k_tile_count = ceil_div(shape<1>(S), get<2>(cta_tiler));
+
+  #pragma unroll
   for(int k_tile = 0; k_tile < k_tile_count; ++k_tile) {
     copy(copy_global, tgS(_,_,_,k_tile), trS);
   }
@@ -152,7 +188,7 @@ int main(int argc, char** argv) {
   using bK = _256;
   using stages = _2;
   using CtaTiler = Shape<bM, _0, bK>; 
-  auto thread_layout = Layout<Shape<_8, _64>, Stride<_64, _1>>{};
+  auto thread_layout = Layout<Shape<_2, _128>, Stride<_128, _1>>{};
   auto smem_layout = Layout<Shape<bM, bK, stages>, Stride<bK, _1, _8192>>{};
 
   auto device_src = compat::malloc<Element>(M * K);

--- a/examples/cute/tutorial/SLM_copy.cpp
+++ b/examples/cute/tutorial/SLM_copy.cpp
@@ -1,0 +1,148 @@
+/***************************************************************************************************
+ * Copyright (c) 2023 - 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * Copyright (c) 2024 - 2024 Codeplay Software Ltd. All rights reserved.
+ * Copyright (C) 2025 Intel Corporation, All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ **************************************************************************************************/
+#include <sycl/sycl.hpp>
+#include <cute/util/compat.hpp>
+#include <sycl/ext/intel/experimental/grf_size_properties.hpp>
+
+#include <cute/tensor.hpp>
+
+#include "cutlass/kernel_hardware_info.h"
+#include "cutlass/platform/platform.h"
+#include "cutlass/tensor_ref.h"
+#include "cutlass/util/sycl_event_manager.hpp"
+#include "cutlass/util/GPU_Clock.hpp"
+#include "cutlass/util/reference/device/gemm_complex.h"
+#include "cutlass/util/reference/device/tensor_compare.h"
+#include "cutlass/util/reference/host/tensor_fill.h"
+
+#include "../../common/sycl_cute_common.hpp"
+
+#if defined(__clang__)
+  #pragma clang diagnostic ignored "-Wpass-failed"
+  #pragma clang diagnostic ignored "-Wdeprecated-declarations"
+#elif defined(__GNUC__)
+  #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#endif
+template<class...> class CopyKernelGlobalName;
+
+using namespace cute;
+namespace syclex = sycl::ext::oneapi::experimental;
+namespace intelex = sycl::ext::intel::experimental;
+// template <class TensorS, class TensorD, class TiledCopy>
+// void copy_kernel_SLM(TensorS S, TensorD D, TiledCopy Op) {
+//   // Shared memory buffers
+//   using Element = typename TensorS::value_type;
+//   auto smem = compat::local_mem<Element[size(S)]>();
+//   auto thr_copy_load = load.get_thread_slice(ThreadIdxX());
+//   Tensor thr_tile_load_S = 
+// }
+
+template<class TensorS, class CtaTiler, class SmemLayout, class ThreadLayout>
+void copy_kernel_naive(TensorS S, CtaTiler cta_tiler, SmemLayout smem_layout, ThreadLayout t_layout) {
+  static_assert(is_static<SmemLayout>::value);
+  using Element = typename TensorS::value_type;
+  auto smem = compat::local_mem<Element[cosize_v<SmemLayout>]>();
+
+  auto cta_coord = make_coord(compat::work_group_id::x(), compat::work_group_id::y(), _);
+  Tensor gS = local_tile(S, cta_tiler, cta_coord, Step<_1, X,_1>{});  // (BLK_M,BLK_K,k)
+  Tensor sD = make_tensor(make_smem_ptr(smem), smem_layout);          // (BLK_M,BLK_K,stages)
+
+  Tensor tgS = local_partition(gS, t_layout, compat::local_id::x());   // (THR_M,THR_N,k)
+  Tensor tsD = local_partition(sD, t_layout, compat::local_id::x());   // (THR_M,THR_N,stages)
+
+  auto K_TILE_MAX = size<2>(tgS);
+  constexpr auto stages = size<2>(tsD);
+  
+  #pragma unroll
+  for(int k_tile = 0; k_tile < K_TILE_MAX; ++k_tile) {
+    copy(tgS(_, _, k_tile), tsD(_, _, k_tile % stages));
+  }
+  
+#if 0
+#define PRINT(x) print(#x ": "); print(x); print("\n");
+  if(cute::thread0()) {
+    PRINT(tgS);
+    PRINT(tsD);
+  }
+#endif
+
+}
+
+int main(int argc, char** argv) {
+  int M = 4096;
+  int K = 4096 * 4;
+
+  using Element = uint32_t;
+
+  std::vector<Element> host_src(M * K);
+
+  for(size_t i = 0; i < M * K; ++i) {
+    host_src[i] = static_cast<Element>(i);
+  }
+  
+  using bM = _32;
+  using bK = _256;
+  using stages = _2;
+  using CtaTiler = Shape<bM, _0, bK>; 
+  auto thread_layout = Layout<Shape<_8, _64>, Stride<_64, _1>>{};
+  auto smem_layout = Layout<Shape<bM, bK, stages>, Stride<bK, _1, _8192>>{};
+
+  auto device_src = compat::malloc<Element>(M * K);
+  compat::memcpy<Element>(device_src, host_src.data(), M * K);
+  Tensor S = make_tensor(make_gmem_ptr(device_src),
+                         make_layout(make_shape(M, K), make_stride(K, 1)));
+
+
+  auto dimBlock = compat::dim3(size(thread_layout));
+  auto dimGrid  = compat::dim3(size(ceil_div(M, bM{})));
+  //
+  // Launch the kernel
+  //
+  GPU_Clock timer;
+  auto iterations = 20;
+
+  timer.start();
+  for (int i = 0; i < iterations; ++i) {
+    auto event = compat::launch<copy_kernel_naive<decltype(S), CtaTiler, decltype(smem_layout),
+                              decltype(thread_layout)>, CopyKernelGlobalName<decltype(S), CtaTiler, decltype(smem_layout),
+                              decltype(thread_layout)>>(
+        dimGrid, dimBlock, S, CtaTiler{}, smem_layout, thread_layout);
+    EventManager::getInstance().addEvent(event);
+
+  }
+  compat::wait();
+  float cute_time = timer.seconds() / iterations;
+  double io = M * K * sizeof(Element) * 1e-12;
+  printf("Performance:     [%4.3f]Gb/s  (%6.4f)ms\n", io / cute_time, cute_time*1000);
+  return 0;
+}


### PR DESCRIPTION
data 4K x 4K uint32_t in which performance is stable. 
naive SLM copy: 
Performance:     [28.364]Gb/s  (0.0024)ms ? this result is suspicious

Pure block 2d copy:
NEW version API:
Performance:     [2.268]Gb/s  (0.0296)ms
OLD version API:
Performance:     [2.484]Gb/s  (0.0270)ms
vectorized SLM + old API  copy: 
Performance:     [2.084]Gb/s  (0.0322)ms
vectorized SLM + new API  copy: 
Performance:     [2.076]Gb/s  (0.0323)ms
1D SLM copy: 

I tried to enable Swizzle in data storage, but no significant compact on it. 